### PR TITLE
Pass jiraConfigs along with edit to determine the row type in backend

### DIFF
--- a/src/common/actions/ds.actions.js
+++ b/src/common/actions/ds.actions.js
@@ -49,7 +49,7 @@ function clearViewDefs() {
     }
 }
 
-function editSingleAttribute (dsName, dsView, dsUser, _id, column, oldVal, newVal, selectorObj, editObj) {
+function editSingleAttribute(dsName, dsView, dsUser, _id, column, oldVal, newVal, selectorObj, editObj, jiraConfig, jiraAgileConfig) {
     return async dispatch => {
         let editTracker = { _id, field: column, oldVal, newVal }
         try {
@@ -59,7 +59,7 @@ function editSingleAttribute (dsName, dsView, dsUser, _id, column, oldVal, newVa
             //let editObj = {};
             //editObj[column] = newVal;
             dispatch(request(_id, editTracker));
-            let responseJson = await dsService.editSingleAttribute({dsName, dsView, dsUser, column, selectorObj, editObj});
+            let responseJson = await dsService.editSingleAttribute({ dsName, dsView, dsUser, column, selectorObj, editObj, jiraConfig, jiraAgileConfig });
             if (responseJson)
                 dispatch(success(_id, editTracker, responseJson));
             else 

--- a/src/common/routes/home/DsView.js
+++ b/src/common/routes/home/DsView.js
@@ -1061,7 +1061,9 @@ class DsView extends Component {
 
         let editObj = {};
         editObj[column] = newVal;
-        dispatch(dsActions.editSingleAttribute(dsName, dsView, user.user, _id, column, oldVal, newVal, selectorObj, editObj));
+        let jiraConfig = dsHome.dsViews[dsView].jiraConfig;
+        let jiraAgileConfig = dsHome.dsViews[dsView].jiraAgileConfig;
+        dispatch(dsActions.editSingleAttribute(dsName, dsView, user.user, _id, column, oldVal, newVal, selectorObj, editObj, jiraConfig, jiraAgileConfig));
 
     }
     


### PR DESCRIPTION
For editing and parsing the jiraAgile row all the way back to JIRA. We need jiraFieldMapping to the backend.