### PR TITLE
Fixed the issue of displaying message after new ds creation

### DIFF
--- a/src/common/routes/home/NewDsStoreMgmt.js
+++ b/src/common/routes/home/NewDsStoreMgmt.js
@@ -96,12 +96,14 @@ export function newDs(state = initialState, action) {
         return {
             ...state,
             status: 'success',
+            createStatus: action.createStatus,
             serverStatus: action.serverStatus
         }
     case newDsConstants.CREATE_DS_FAILURE:
         return {
             ...state,
             status: 'fail',
+            createStatus: action.createStatus,
             serverStatus: action.serverStatus,
         }
     


### PR DESCRIPTION
Bug fix: 
No message is getting displayed after creating a new database using excel file but message is getting displayed after copying ds from another ds. Fixed the issue.